### PR TITLE
Add EnableSendfile Off to Virtualhost

### DIFF
--- a/templates/default/apache_vhost.erb
+++ b/templates/default/apache_vhost.erb
@@ -46,4 +46,5 @@
   </IfModule>
 
 <% end -%>
+  EnableSendfile Off
 </VirtualHost>


### PR DESCRIPTION
To fix some weird issues like owncloud/core#7638 and probably onddo/owncloud-cookbook#10 `EnableSendfile Off` has to be added to the virtualhost. 

I hope this can be merged?

Thanks for this cookbook :)
